### PR TITLE
Fix concurrency issue with sending websocket packets

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -2,6 +2,8 @@ package turnpike
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/gorilla/websocket"
 )
 
@@ -10,6 +12,7 @@ type websocketPeer struct {
 	serializer  Serializer
 	messages    chan Message
 	payloadType int
+	mutex       sync.Mutex
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
@@ -67,6 +70,8 @@ func (ep *websocketPeer) Send(msg Message) error {
 	if err != nil {
 		return err
 	}
+	ep.mutex.Lock()
+	defer ep.mutex.Unlock()
 	return ep.conn.WriteMessage(ep.payloadType, b)
 }
 func (ep *websocketPeer) Receive() <-chan Message {


### PR DESCRIPTION
Autobahn Python was reporting a websocket protocol violation. Adding this mutex fixed that.
