### PR TITLE
Ensure MsgPack uses Bin Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
+
+### Go template
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
 *.so
-# test binaries
-*.test
 
 # Folders
 _obj
@@ -22,6 +22,18 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+*.test
+*.prof
 
-# Editor cruft
-*.swp
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# external packages folder
+vendor/
+
+# embedded gopath
+gopath/
+
+
+### Jetbrains IDE
+.idea/

--- a/serialize.go
+++ b/serialize.go
@@ -149,13 +149,16 @@ type MessagePackSerializer struct {
 // Serialize encodes a Message into a msgpack payload.
 func (s *MessagePackSerializer) Serialize(msg Message) ([]byte, error) {
 	var b []byte
-	return b, codec.NewEncoderBytes(&b, new(codec.MsgpackHandle)).Encode(toList(msg))
+	var h codec.MsgpackHandle
+	h.WriteExt = true
+	return b, codec.NewEncoderBytes(&b, &h).Encode(toList(msg))
 }
 
 // Deserialize decodes a msgpack payload into a Message.
 func (s *MessagePackSerializer) Deserialize(data []byte) (Message, error) {
 	var arr []interface{}
-	if err := codec.NewDecoderBytes(data, new(codec.MsgpackHandle)).Decode(&arr); err != nil {
+	var h codec.MsgpackHandle
+	if err := codec.NewDecoderBytes(data, &h).Decode(&arr); err != nil {
 		return nil, err
 	} else if len(arr) == 0 {
 		return nil, fmt.Errorf("Invalid message")


### PR DESCRIPTION
Although I just started using WAMP; it appears that `crossbar` uses the new MsgPack specification, where bytes and strings can be differentiated. 

When sending binary (`[]byte`), crossbar would emit: `autobahn.wamp.exception.ProtocolError: invalid serialization of WAMP message (unpacked string is invalid utf-8)` thereby preventing the message from being routed to the intended WAMP component.

With these changes, everything works as expected, and the components are able to receive and process the binary data.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/beatgammit/turnpike/3)
<!-- Reviewable:end -->
