### PR TITLE
Manually close connection on unexpected errors

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -164,7 +164,8 @@ func (ep *websocketPeer) run() {
 				log.Println("peer connection closed")
 			} else {
 				log.Println("error reading from peer:", err)
-				if !websocket.IsCloseError(err) {
+				// only expected errors seem to close the connection, so close on any unexpected errors
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 					ep.conn.Close()
 				}
 			}


### PR DESCRIPTION
Errors such as CloseAbnormalClosure(1006) don't close the connection.

This manually closes the connection if the error isn't CloseNormalClosure(1000) or CloseGoingAway(1001).